### PR TITLE
 Fix build failure on PG19 (clang+LTO and gcc) caused by implicit fun…

### DIFF
--- a/src/pgmeminfo.c
+++ b/src/pgmeminfo.c
@@ -16,10 +16,12 @@
 
 #include "access/tupdesc.h"
 #include "access/htup.h"
+#include "access/htup_details.h"
 #include "catalog/pg_type.h"
 
 #include "mb/pg_wchar.h"
 #include "utils/builtins.h"
+#include "utils/tuplestore.h"
 
 #include <malloc.h>
 


### PR DESCRIPTION
Fix build failure on PG19 (clang+LTO and gcc) caused by implicit declarations:

     * heap_form_tuple()	-> declared in access/htup_details.h, not access/htup.h (which only has the HeapTuple typedef/struct).
     * tuplestore_begin_heap() -> declared in utils/tuplestore.h.
     * tuplestore_putvalues()  -> declared in utils/tuplestore.h.
  
   Both headers were missing from the includes, so under  -Wimplicit-function-declaration (default-error in newer  clang gcc, and always fatal for pointer-returning functions  since C99 disallows implicit int-to-pointer) the build aborted.
   
   Coded by Claude, tested by me.